### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-and-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/ngeorgieff/pico2w-sht30-mqtt/security/code-scanning/2](https://github.com/ngeorgieff/pico2w-sht30-mqtt/security/code-scanning/2)

To fix this problem, explicitly specify the minimal set of permissions that the job requires, using a `permissions` block. Since the workflow only needs write permissions to create releases and upload assets (for the `softprops/action-gh-release` step), all other default permissions can be set to read, and only `contents: write` should be granted. The `permissions` block should be placed at the job level (`build-and-release`), unless multiple jobs in the workflow require the same permissions (which is not the case here). This can be achieved by adding the following block under `build-and-release:` and above `runs-on: ubuntu-latest`:

```yaml
permissions:
  contents: write
```

No additional dependencies, imports, or method changes are required—this is a pure YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
