### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "**" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ngeorgieff/pico2w-sht30-mqtt/security/code-scanning/1](https://github.com/ngeorgieff/pico2w-sht30-mqtt/security/code-scanning/1)

The best way to fix the problem is to add a `permissions:` block specifying `contents: read` either at the root of the workflow (which applies to all jobs unless overridden) or at the job level. Since there's only one job and it does not require write access, we can safely add the following at the top level, just below or above `on:`:  
```yaml
permissions:
  contents: read
```  
No other code changes, imports, or additional definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
